### PR TITLE
Process weights first

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 accelerate==0.26.1
-aiohttp==3.9.0
+aiohttp==3.9.0b0
 aiosignal==1.3.1
 annotated-types==0.6.0
 ansible==6.7.0
@@ -18,7 +18,7 @@ Babel==2.13.1
 backoff==2.2.1
 base58==2.1.1
 beautifulsoup4==4.12.2
-bittensor==6.6.1
+bittensor==6.7.2
 black==23.7.0
 bleach==6.1.0
 certifi==2023.11.17
@@ -209,7 +209,7 @@ sniffio==1.3.0
 soupsieve==2.5
 stack-data==0.6.3
 starlette==0.27.0
-substrate-interface==1.5.2
+substrate-interface==1.7.5
 sympy==1.12
 termcolor==2.4.0
 terminado==0.17.1

--- a/validation/validator_api_server/core_validator.py
+++ b/validation/validator_api_server/core_validator.py
@@ -94,15 +94,15 @@ class CoreValidator:
         self.score_task.add_done_callback(validation_utils.log_task_exception)
 
     async def periodically_resync_and_set_weights(self) -> None:
-        time_between_resyncing = 1 * 60
+        time_between_resyncing =  0.5 * 60
         while True:
             await self.resync_metagraph()
+            await self.set_weights()
             await asyncio.sleep(time_between_resyncing)
             
-            await self.resync_metagraph()
-            await asyncio.sleep(time_between_resyncing)
+            # await self.resync_metagraph()
+            # await asyncio.sleep(time_between_resyncing)
 
-            await self.set_weights()
 
     async def _query_checking_server_for_expected_result(
         self, endpoint: str, synapse: bt.Synapse, outgoing_model: BaseModel
@@ -696,6 +696,7 @@ class CoreValidator:
                 wait_for_finalization=True,
                 wait_for_inclusion=True,
             )
+            return success, message
 
 
         attempts = 0

--- a/validation/validator_api_server/core_validator.py
+++ b/validation/validator_api_server/core_validator.py
@@ -94,7 +94,7 @@ class CoreValidator:
         self.score_task.add_done_callback(validation_utils.log_task_exception)
 
     async def periodically_resync_and_set_weights(self) -> None:
-        time_between_resyncing = 10 * 60
+        time_between_resyncing = 1 * 60
         while True:
             await self.resync_metagraph()
             await asyncio.sleep(time_between_resyncing)

--- a/validation/validator_api_server/core_validator.py
+++ b/validation/validator_api_server/core_validator.py
@@ -93,7 +93,7 @@ class CoreValidator:
         self.score_task.add_done_callback(validation_utils.log_task_exception)
 
     async def periodically_resync_and_set_weights(self) -> None:
-        time_between_resyncing = 10 * 60
+        time_between_resyncing = 1 * 60
         while True:
             await self.resync_metagraph()
             await asyncio.sleep(time_between_resyncing)

--- a/validation/validator_api_server/core_validator.py
+++ b/validation/validator_api_server/core_validator.py
@@ -93,7 +93,7 @@ class CoreValidator:
         self.score_task.add_done_callback(validation_utils.log_task_exception)
 
     async def periodically_resync_and_set_weights(self) -> None:
-        time_between_resyncing = 1 * 60
+        time_between_resyncing = 10 * 60
         while True:
             await self.resync_metagraph()
             await asyncio.sleep(time_between_resyncing)

--- a/validation/validator_api_server/core_validator.py
+++ b/validation/validator_api_server/core_validator.py
@@ -42,6 +42,7 @@ def _pascal_to_kebab(input_string: str) -> str:
 
 MAX_PERIODS_TO_LOOK_FOR_SCORE = 30
 
+
 class CoreValidator:
     def __init__(self) -> None:
         self.config = self.prepare_config_and_logging()
@@ -92,7 +93,7 @@ class CoreValidator:
         self.score_task.add_done_callback(validation_utils.log_task_exception)
 
     async def periodically_resync_and_set_weights(self) -> None:
-        time_between_resyncing =  10 *60
+        time_between_resyncing = 10 * 60
         while True:
             await self.resync_metagraph()
             await asyncio.sleep(time_between_resyncing)
@@ -485,10 +486,10 @@ class CoreValidator:
 
         if all([result.response_time is None for result in [result1, result2]]):
             return {}
-        
+
         if result1.response_time is None:
             axon_scores[result1.axon_uid] = slower_response_penalty
-        
+
         elif result2.response_time is None:
             axon_scores[result2.axon_uid] = slower_response_penalty
 
@@ -618,7 +619,6 @@ class CoreValidator:
             return None
 
     async def set_weights(self):
-
         bt.logging.info("Setting weights!")
 
         uid_scores: Dict[int, List[float]] = {}
@@ -635,27 +635,22 @@ class CoreValidator:
                         average_score = 0.85
                     else:
                         average_score = uid_info.average_score
-                    
 
-                    score = (multiplier * max(average_score, 0.80))
+                    score = multiplier * max(average_score, 0.80)
 
                     uid_scores[uid_info.uid] = uid_scores.get(uid_info.uid, []) + [score]
-
 
         uid_weights: Dict[int, float] = {}
         discount_factor = 0.1
         for uid, scores in uid_scores.items():
             scores_reversed = list(reversed(scores))
             n = len(scores_reversed)
-            weights = [1/(1+discount_factor*i) for i in range(n)]
+            weights = [1 / (1 + discount_factor * i) for i in range(n)]
             sum_weights = sum(weights)
-            weights = [w/sum_weights for w in weights]  # The sum of these normalized weights is 1
+            weights = [w / sum_weights for w in weights]
             discounted_score = sum(score * weight for score, weight in zip(scores_reversed, weights))
 
             uid_weights[uid] = discounted_score
-
-        
-        bt.logging.debug(f"Uid weights: {uid_weights}")
 
 
 
@@ -663,22 +658,9 @@ class CoreValidator:
             bt.logging.info("No scores found, nothing to set")
             return
 
-        # Just for logging purposes:
-        # Normalize avg_scores to a range of 0 to 1
-        uid_weights_sorted = dict(sorted(uid_weights.items()))
-
-        uids_in_order = list(uid_weights_sorted.keys())
-        uids_values_in_order = list(uid_weights_sorted.values())
-
-        total_scores = torch.tensor(uids_values_in_order)
-        min_score = torch.min(total_scores)
-        max_score = torch.max(total_scores)
-        if max_score - min_score != 0:
-            normalized_scores = (total_scores - min_score) / (max_score - min_score)
-        else:
-            normalized_scores = torch.zeros_like(total_scores)
-
-        bt.logging.info(f"Settings weights with normalized scores: {normalized_scores}")
+        weights_tensor = torch.zeros_like(self.metagraph.S, dtype=torch.float32)
+        for uid, weight in uid_weights.items():
+            weights_tensor[uid] = weight
 
         try:
             netuid = self.config.netuid
@@ -687,14 +669,27 @@ class CoreValidator:
         except AttributeError:
             netuid = 19
 
-        attempts = 0 
-        while attempts < 2:
+        (
+            processed_weight_uids,
+            processed_weights,
+        ) = bt.utils.weight_utils.process_weights_for_netuid(
+            uids=self.metagraph.uids.to("cpu"),
+            weights=weights_tensor.to("cpu"),
+            netuid=netuid,
+            subtensor=self.subtensor,
+            metagraph=self.metagraph,
+        )
 
+        for uid, weight in zip(processed_weight_uids, processed_weights):
+            bt.logging.info(f"UID: {uid.item()} -> Weight: {weight.item()}")
+
+        attempts = 0
+        while attempts < 2:
             success = self.subtensor.set_weights(
                 wallet=self.wallet,
                 netuid=netuid,
-                uids=uids_in_order,
-                weights=uids_values_in_order,
+                uids=processed_weight_uids,
+                weights=processed_weights,
                 version_key=VERSION_KEY,
                 wait_for_finalization=False,
                 wait_for_inclusion=False,
@@ -711,6 +706,3 @@ class CoreValidator:
                 else:
                     bt.logging.info("❌ Failed to set weights! Trying again...")
                     await asyncio.sleep(60)
-
-
-        

--- a/validation/validator_api_server/core_validator.py
+++ b/validation/validator_api_server/core_validator.py
@@ -686,9 +686,7 @@ class CoreValidator:
         # for uid, weight in zip(processed_weight_uids, processed_weights):
         #     bt.logging.info(f"UID: {uid.item()} -> Weight: {weight.item()}")
 
-        attempts = 0
-        max_attempts = 10
-        while attempts < max_attempts:
+        async def subtensor_set_weights(netuid, processed_weight_uids, processed_weights):
             success, message = self.subtensor.set_weights(
                 wallet=self.wallet,
                 netuid=netuid,
@@ -698,6 +696,17 @@ class CoreValidator:
                 wait_for_finalization=True,
                 wait_for_inclusion=True,
             )
+
+
+        attempts = 0
+        max_attempts = 10
+        while attempts < max_attempts:
+            set_weights_task = asyncio.create_task(subtensor_set_weights(netuid, processed_weight_uids, processed_weights))
+
+            # To get results
+            success, message = await set_weights_task
+            print(f'Success: {success}, Message: {message}')
+
             if success:
                 bt.logging.info("✅ Done setting weights!")
                 attempts = max_attempts

--- a/validation/validator_api_server/core_validator.py
+++ b/validation/validator_api_server/core_validator.py
@@ -94,14 +94,15 @@ class CoreValidator:
         self.score_task.add_done_callback(validation_utils.log_task_exception)
 
     async def periodically_resync_and_set_weights(self) -> None:
-        time_between_resyncing =  0.5 * 60
+        time_between_resyncing =  10 * 60
         while True:
             await self.resync_metagraph()
-            await asyncio.to_thread(self.set_weights)
             await asyncio.sleep(time_between_resyncing)
             
-            # await self.resync_metagraph()
-            # await asyncio.sleep(time_between_resyncing)
+            await asyncio.to_thread(self.set_weights)
+
+            await self.resync_metagraph()
+            await asyncio.sleep(time_between_resyncing)
 
 
     async def _query_checking_server_for_expected_result(

--- a/validation/validator_api_server/core_validator.py
+++ b/validation/validator_api_server/core_validator.py
@@ -97,7 +97,7 @@ class CoreValidator:
         time_between_resyncing =  0.5 * 60
         while True:
             await self.resync_metagraph()
-            await asyncio.to_thread(self.set_weights())
+            await asyncio.to_thread(self.set_weights)
             await asyncio.sleep(time_between_resyncing)
             
             # await self.resync_metagraph()
@@ -686,7 +686,7 @@ class CoreValidator:
         # for uid, weight in zip(processed_weight_uids, processed_weights):
         #     bt.logging.info(f"UID: {uid.item()} -> Weight: {weight.item()}")
 
-        async def subtensor_set_weights(netuid, processed_weight_uids, processed_weights):
+        def subtensor_set_weights(netuid, processed_weight_uids, processed_weights):
             success, message =   self.subtensor.set_weights(
                 wallet=self.wallet,
                 netuid=netuid,

--- a/validation/validator_api_server/core_validator.py
+++ b/validation/validator_api_server/core_validator.py
@@ -683,28 +683,20 @@ class CoreValidator:
             metagraph=self.metagraph,
         )
 
-        # for uid, weight in zip(processed_weight_uids, processed_weights):
-        #     bt.logging.info(f"UID: {uid.item()} -> Weight: {weight.item()}")
 
-        def subtensor_set_weights(netuid, processed_weight_uids, processed_weights):
-            success, message =   self.subtensor.set_weights(
+        attempts = 0
+        max_attempts = 20
+        while attempts < max_attempts:
+
+            success, message = self.subtensor.set_weights(
                 wallet=self.wallet,
                 netuid=netuid,
                 uids=processed_weight_uids,
                 weights=processed_weights,
                 version_key=VERSION_KEY,
-                wait_for_finalization=True,
+                wait_for_finalization=False,
                 wait_for_inclusion=True,
             )
-            return success, message
-
-
-        attempts = 0
-        max_attempts = 10
-        while attempts < max_attempts:
-
-            # To get results
-            success, message = subtensor_set_weights(netuid, processed_weight_uids, processed_weights)
             print(f'Success: {success}, Message: {message}')
 
             if success:

--- a/validation/validator_api_server/validation_utils.py
+++ b/validation/validator_api_server/validation_utils.py
@@ -82,7 +82,7 @@ def connect_to_checking_servers(config) -> Tuple[str, str]:
                 bt.logging.info(f"Health check successful - connected to {name} at {url}.")
                 break
             else:
-                bt.logging.info(f"{name} not reachable. Sleeping for {retry_interval} second(s) before retrying.")
+                bt.logging.info(f"{name} not reachable just yet- it's probably still starting. Sleeping for {retry_interval} second(s) before retrying.")
                 time.sleep(retry_interval)
                 retry_interval += 0.5
                 if retry_interval > 10:

--- a/validation/validator_checking_server/checking_server.py
+++ b/validation/validator_checking_server/checking_server.py
@@ -34,7 +34,7 @@ if __name__ == "__main__":
     for i, load_function in enumerate(singleton.resource_name_to_load_function.values()):
         bt.logging.info(f"Loading model {i}, might take a minute or so")
         load_function()
-        singleton.unload_all_models()
+        singleton.move_all_models_to_cpu()
 
     singleton.load_validator_resources()
     singleton.load_resource(cst.MODEL_CACHE)


### PR DESCRIPTION
- Weight setting wait for inclusion only but try a *bunch* of times
- Make sure weights are properly assigned to each UID
- Move models to CPU, not unload them, when loading the checking server