### PR TITLE
API proxy to run separate from GPU, with autoupdates + fix for dendrite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -183,4 +183,4 @@ dmypy.json
 # Cython debug symbols
 cython_debug/
 
-
+.idea/

--- a/autoupdate_api_server.sh
+++ b/autoupdate_api_server.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# THIS FILE CONTAINS THE STEPS NEEDED TO AUTOMATICALLY UPDATE THE REPO ON A TAG CHANGE
+# THIS FILE ITSELF MAY CHANGE FROM UPDATE TO UPDATE, SO WE CAN DYNAMICALLY FIX ANY ISSUES
+
+# SOME STEPS ARE COMMENTED OUT IN THIS UPDATE AS THEY ARE NOT NEEDED
+
+pm2 delete "api_server"
+
+# ./get_models.sh
+
+
+# if command -v pip &> /dev/null
+# then
+#     ### Install the local python environment using pip
+#     pip install --upgrade pip
+#     pip install -e .
+#     pip install -r git_requirements.txt
+# else
+#     ### Install the local python environment using pip3
+#     pip3 install --upgrade pip
+#     pip3 install -e .
+#     pip3 install -r git_requirements.txt
+# fi
+
+./validation/api_server.sh

--- a/autoupdate_run_worker_servers.sh
+++ b/autoupdate_run_worker_servers.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# THIS FILE CONTAINS THE STEPS NEEDED TO AUTOMATICALLY UPDATE THE REPO ON A TAG CHANGE
+# THIS FILE ITSELF MAY CHANGE FROM UPDATE TO UPDATE, SO WE CAN DYNAMICALLY FIX ANY ISSUES
+
+# SOME STEPS ARE COMMENTED OUT IN THIS UPDATE AS THEY ARE NOT NEEDED
+
+pm2 delete "safety_server"
+pm2 delete "checking_server"
+
+# ./get_models.sh
+
+
+# if command -v pip &> /dev/null
+# then
+#     ### Install the local python environment using pip
+#     pip install --upgrade pip
+#     pip install -e .
+#     pip install -r git_requirements.txt
+# else
+#     ### Install the local python environment using pip3
+#     pip3 install --upgrade pip
+#     pip3 install -e .
+#     pip3 install -r git_requirements.txt
+# fi
+
+./validation/run_worker_servers.sh

--- a/core/bittensor_overrides.py
+++ b/core/bittensor_overrides.py
@@ -12,6 +12,24 @@ class dendrite(bittensor.dendrite):
         # info = {"headers": synapse.to_headers(), "json": synapse.dict()}
         # bittensor.logging.info(f"{info}")
 
+    def _get_endpoint_url(self, target_axon, request_name):
+        """
+        Constructs the endpoint URL for a network request to a target axon.
+
+        This internal method generates the full HTTP URL for sending a request to the specified axon. The
+        URL includes the IP address and port of the target axon, along with the specific request name. 
+
+        Args:
+            target_axon: The target axon object containing IP and port information.
+            request_name: The specific name of the request being made.
+
+        Returns:
+            str: A string representing the complete HTTP URL for the request.
+        """
+        endpoint = f"{target_axon.ip}:{str(target_axon.port)}"
+        return f"http://{endpoint}/{request_name}"
+
+
     async def forward(
         self,
         axons: Union[

--- a/run_validator_auto_update.py
+++ b/run_validator_auto_update.py
@@ -1,6 +1,9 @@
 import os
 import subprocess
 import time
+from typer import Typer
+
+app = Typer()
 
 
 def should_update_local(local_tag, remote_tag):
@@ -8,33 +11,47 @@ def should_update_local(local_tag, remote_tag):
         return remote_tag != local_tag
     return False
 
-subprocess.call(["./validation/run_all_servers.sh"], shell=True)
 
-while True:
-
-    local_tag = subprocess.getoutput('git describe --abbrev=0 --tags')
-    os.system('git fetch')
-    remote_tag = subprocess.getoutput('git describe --tags `git rev-list --tags --max-count=1`')
-
-    if should_update_local(local_tag, remote_tag):
-        print("Local repo is not up-to-date. Updating...")
-        reset_cmd = 'git reset --hard ' + remote_tag
-        process = subprocess.Popen(reset_cmd.split(), stdout=subprocess.PIPE)
-        output, error = process.communicate()
-
-        if error:
-            print("Error in updating:", error)
-        else:
-            print("Updated local repo to latest version: {}", format(remote_tag))
-
-            print("Running the autoupdate steps...")
-            # Trigger shell script. Make sure this file path starts from root
-            subprocess.call(["./autoupdate_steps.sh"], shell=True)
-
-            print("Finished running the autoupdate steps! Ready to go 😎")
+def run_servers(start_servers_script="run_all_servers.sh"):
+    subprocess.call(["./validation/" + start_servers_script], shell=True)
 
 
+def update_local(remote_tag, start_servers_script):
+    reset_cmd = 'git reset --hard ' + remote_tag
+    process = subprocess.Popen(reset_cmd.split(), stdout=subprocess.PIPE)
+    output, error = process.communicate()
+    if error:
+        print("Error in updating:", error)
     else:
-        print("Repo is up-to-date.")
+        print("Updated local repo to latest version: {}", format(remote_tag))
 
-    time.sleep(60)
+        print("Running the autoupdate steps...")
+        # Trigger shell script. Make sure this file path starts from root
+        if start_servers_script == "run_all_servers.sh":
+            autoupdate_script = "./autoupdate_steps.sh"  # So we don't break legacy running servers
+        else:
+            autoupdate_script = "./autoupdate_" + start_servers_script
+        subprocess.call([autoupdate_script], shell=True)
+
+        print("Finished running the autoupdate steps! Ready to go 😎")
+
+
+@app.command()
+def run_and_keep_updated(start_servers_script: str = "run_all_servers.sh"):
+    run_servers(start_servers_script)
+    while True:
+        local_tag = subprocess.getoutput('git describe --abbrev=0 --tags')
+        os.system('git fetch')
+        remote_tag = subprocess.getoutput('git describe --tags `git rev-list --tags --max-count=1`')
+
+        if should_update_local(local_tag, remote_tag):
+            print("Local repo is not up-to-date. Updating...")
+            update_local(remote_tag=remote_tag, start_servers_script=start_servers_script)
+        else:
+            print("Repo is up-to-date.")
+
+        time.sleep(60)
+
+
+if __name__ == "__main__":
+    app()

--- a/validation/run_worker_servers.sh
+++ b/validation/run_worker_servers.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+"$SCRIPT_DIR/safety_server.sh"
+sleep 30
+"$SCRIPT_DIR/checking_server.sh"
+sleep 30


### PR DESCRIPTION
Dendrite fix;

Problem is that if a miner has the same ip as a validator, the validator cannot query them. Since providers like runpod all share IP address', a lot of miners are unfairly penalised. I'm not sure why this was in the bittensor code originally, but this patch takes it out

We are also making it a lot easier to run a separate proxy service for the validators, separate to their gpu instances